### PR TITLE
State the purpose of the lib in the README and the fact that for numbers without an integer root it returns the floor-ed value

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![NPM](https://nodei.co/npm/bigint-isqrt.png?downloads=true&stars=true)](https://nodei.co/npm/bigint-isqrt/)
 
+A function that returns the square root (or it's [floor](https://en.wikipedia.org/wiki/Floor_and_ceiling_functions)-ed value if the root is not an integer) of a [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) number.
+
 ======================
 
 example:


### PR DESCRIPTION
Hi. I think this update will greatly improve experience of people using this lib, as it wasn't clear whether it threw an error or returned the floor-ed value in case of no integer root.