### PR TITLE
Minor speed improvements and a correctness fix.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,28 +1,31 @@
-var sqrt = function (value) {
+const i52 = 1n << 52n;
+
+const sqrt = function (value) {
 	if (value < 2n) {
 		return value;
 	}
 
 	if (value < 16n) {
-		return BigInt(Math.floor(Math.sqrt(Number(value))));
+		return BigInt(Math.sqrt(Number(value)|0));
 	}
 	
-	if(value < (1n << 52n)){
-		var x1 = BigInt(Math.floor(Math.sqrt(Number(value))))-3n;
+	let x1;
+	if(value < i52){
+		x1 = BigInt((Math.sqrt(Number(value))|0) - 3);
 	} else {
-		let vlen = value.toString().length;
-		if (vlen%2==0) {
-			var x1 = 10n**(BigInt(vlen/2));
+		const vlen = value.toString().length;
+		if (!(vlen&1)) {
+			x1 = 10n**(BigInt(vlen/2));
 		} else {
-			var x1 = 4n*10n**(BigInt((vlen)/2));
+			x1 = 40n**(BigInt((vlen/2)|0));
 		}
 	}
 
-	let x0 = -1n;
-	while((x0 !== x1 && x0 !== (x1 - 1n))){
+	let x0;
+	do {
 		x0 = x1;
 		x1 = ((value / x0) + x0) >> 1n;
-	}
+	} while ((x0 !== x1 && x0 !== (x1 - 1n)));
 	return x0;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigint-isqrt",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Square root of BigInts",
   "main": "main.js",
   "directories": {


### PR DESCRIPTION
1. Integer coercion with bitwise operators is faster than Math.floor.
2. `var x1 = 4n*10n**(BigInt((vlen)/2));` always throws an exception, since vlen/2 in this branch is guaranteed to be non-integer; added integer coercion to integer to make tests pass.
3. `1n << 52n` can be precomputed and cached.
4. Bitwise masking is faster than the remainder operator for checking the parity of `vlen`.
5. One round of conditional checks can be eliminated by replacing the `while` loop with a `do-while`.